### PR TITLE
iam access analayzer

### DIFF
--- a/modules/aws-organization/org.tf
+++ b/modules/aws-organization/org.tf
@@ -5,7 +5,8 @@ resource "aws_organizations_organization" "org" {
     "config.amazonaws.com",
     "controltower.amazonaws.com",
     "member.org.stacksets.cloudformation.amazonaws.com",
-    "sso.amazonaws.com"
+    "sso.amazonaws.com",
+    "access-analyzer.amazonaws.com"
   ]
   feature_set = "ALL"
 }

--- a/modules/controls-validation/lambda/main.py
+++ b/modules/controls-validation/lambda/main.py
@@ -1,5 +1,0 @@
-def handler(event, context):
-    return {
-        'statusCode': 200,
-        'body': 'Hello from inline Lambda!'
-    }

--- a/modules/security-foundation/.terraform.lock.hcl
+++ b/modules/security-foundation/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.0.0-beta3"
+  constraints = "6.0.0-beta3"
+  hashes = [
+    "h1:kMAaOX2uac8mLXzvfG1OODk0ue+sFsyFGFRyQVeaetU=",
+    "zh:2bc58cf176e0c365f5c7682430197a1c36b13b75f4ad6a4208efb6b654cd7164",
+    "zh:300222d1c5d51532f2dbf9ae1eb1ea10575cdd56f75c4c65ab8bceead4ee3669",
+    "zh:5799a243f98bdd20edf961ebcba05b65f12fe89014494fb4b75ac4e767972429",
+    "zh:596f99777bfc3971d0ff0329cba6797adc655149b45013ae9e32055f4d4ae9d8",
+    "zh:59c6bc732bd123c06c41b59e6a2b008692bf5984e6a13ec661c1de83ca02fe25",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9ba82f3280133a011987b014a58e9b1e13df61dc86c96ca4080562c2eef011e8",
+    "zh:a06e2029986a0f513c7fee2b52b04f3d758f705478ba40b353eae148fe02cafe",
+    "zh:a123235ce1f8a749968e5b14433311b3338f73f5244f36e1f2525265b5fe48f7",
+    "zh:b6ea3f8aa2389d4d9de86d4db43c2dbe0d269231727111d90730409b7252bb6e",
+    "zh:b921f0a15166e32beda68de3436da7dae81bedcb13c69517aef1624ea5f24d46",
+    "zh:d25cf251b15d98faf6d3d0dd1c9962be0893561a2d74f985e9a385b6806b593d",
+    "zh:d49aea36f0cfd5c40c8eae0beed38ef669e7d5e70236eaa7487c500916373053",
+    "zh:d9347b37fec437470ad5b77fe988ea678d4e8e91e4607c128460d915b7f529fd",
+    "zh:f81705821061f6acf4d145644ce603cf267936b9fe850380223ed3f31081e6d0",
+  ]
+}

--- a/modules/security-foundation/iam-access-analyzer.tf
+++ b/modules/security-foundation/iam-access-analyzer.tf
@@ -1,0 +1,35 @@
+resource "aws_accessanalyzer_analyzer" "access_analyzer_external_organization" {
+  analyzer_name = "control-tower-access-analyzer-external-organization"
+  type          = "ORGANIZATION"
+}
+
+resource "aws_accessanalyzer_analyzer" "access_analyzer_unused_access_organization" {
+  analyzer_name = "control-tower-access-analyzer-unused-access-organization"
+  type          = "ORGANIZATION_UNUSED_ACCESS"
+
+  configuration {
+    unused_access {
+      unused_access_age = 180
+    }
+  }
+}
+
+#############################################################
+# IAM Access Analyzer validation
+#############################################################
+resource "aws_iam_role" "cross_account_role" {
+  count = var.validate_iam_access_analyzer ? 1 : 0
+  name  = "cross-account-invoke-lambda-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        AWS = "arn:aws:iam::${var.external_account_id}:root"
+      }
+      Action = "sts:AssumeRole"
+    }]
+  })
+  depends_on = [aws_accessanalyzer_analyzer.access_analyzer_external_organization]
+}

--- a/modules/security-foundation/terraform.tf
+++ b/modules/security-foundation/terraform.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "6.0.0-beta3"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/security-foundation/variables.tf
+++ b/modules/security-foundation/variables.tf
@@ -1,0 +1,10 @@
+variable "external_account_id" {
+  type    = string
+  default = "123456789012" # replace with actual external account ID
+}
+
+variable "validate_iam_access_analyzer" {
+  description = "Flag to enable or disable IAM Access Analyzer validation"
+  type        = bool
+  default     = false
+}

--- a/terraform.tf
+++ b/terraform.tf
@@ -21,10 +21,13 @@ provider "aws" {
   region = "eu-west-1"
 }
 
-# Comment out this provider block if you are not using a production profile
-# and dont need to validate the Control Tower Landing Zone Controls
-provider "aws" {
-  alias   = "production"
-  profile = "production"
-  region  = "eu-west-1"
-}
+############################################################################
+# UnComment out this provider block if you are using a production profile
+# and want to validate the Control Tower Landing Zone Controls
+############################################################################
+
+# provider "aws" {
+#   alias   = "production"
+#   profile = "production"
+#   region  = "eu-west-1"
+# }

--- a/variables.tf
+++ b/variables.tf
@@ -58,8 +58,9 @@ variable "enable_controls" {
   default     = true
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "validate_controls" {
   description = "Flag to validate controls"
   type        = bool
-  default     = true
+  default     = false
 }


### PR DESCRIPTION
- adding IAM access analyser 
- removing the control validation block and convert to comment
- fixing pre-commit error as a side effect of not using the validate control caused by flint terraform unused variable