### PR TITLE
adding aws securityhub initial code

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "current" {}

--- a/locals.tf
+++ b/locals.tf
@@ -41,4 +41,19 @@ locals {
 
   }
 
+  security_hub_member_invite = {
+    management = {
+      account_id = data.aws_caller_identity.current.account_id
+      email      = var.management_account_email
+    }
+    logging = {
+      account_id = var.logging_account_id
+      email      = var.logging_account_email
+    }
+    production = {
+      account_id = var.production_account_id
+      email      = var.production_account_email
+    }
+  }
+
 }

--- a/main.tf
+++ b/main.tf
@@ -63,5 +63,38 @@ module "security_foundation_security" {
     aws = aws.security
   }
   validate_iam_access_analyzer = false
+  security_hub_member_invite   = local.security_hub_member_invite
   depends_on                   = [module.control_tower_landing_zone, module.organization, module.security_foundation_management]
 }
+
+#######################################################################################
+# OPTIONAL MODULE FOR SECURITY HUB INVITE ACCEPTOR
+# This module is used to accept Security Hub invitations from the Security Account
+#######################################################################################
+
+# module "securityhub_invite_master_account" {
+#   count                             = var.enable_invite_acceptors ? 1 : 0
+#   source                            = "./modules/securityhub-invite"
+#   aws_securityhub_admin_account_id  = var.security_account_id
+#   depends_on                        = [module.security_foundation_security]
+# }
+
+# module "securityhub_invite_logging_account" {
+#   count                             = var.enable_invite_acceptors ? 1 : 0
+#   source                            = "./modules/securityhub-invite"
+#     providers = {
+#     aws = aws.logging
+#   }
+#   aws_securityhub_admin_account_id  = var.security_account_id
+#   depends_on                        = [module.security_foundation_security]
+# }
+
+# module "securityhub_invite_product_account" {
+#   count                             = var.enable_invite_acceptors ? 1 : 0
+#   source                            = "./modules/securityhub-invite"
+#       providers = {
+#     aws = aws.production
+#   }
+#   aws_securityhub_admin_account_id  = var.security_account_id
+#   depends_on                        = [module.security_foundation_security]
+# }

--- a/modules/aws-organization/delegated-admin.tf
+++ b/modules/aws-organization/delegated-admin.tf
@@ -13,7 +13,8 @@ resource "aws_organizations_delegated_administrator" "delegated_admins" {
     if !contains([
       "guardduty.amazonaws.com",
       "malware-protection.guardduty.amazonaws.com",
-      "auditmanager.amazonaws.com"
+      "auditmanager.amazonaws.com",
+      "securityhub.amazonaws.com",
     ], svc)
   } : {}
 

--- a/modules/security-foundation-management/securityhub.tf
+++ b/modules/security-foundation-management/securityhub.tf
@@ -1,0 +1,6 @@
+resource "aws_securityhub_account" "sec_hub" {}
+
+resource "aws_securityhub_organization_admin_account" "sec_hub_admin" {
+  depends_on       = [aws_securityhub_account.sec_hub]
+  admin_account_id = var.aws_security_account_id
+}

--- a/modules/security-foundation-security/securityhub.tf
+++ b/modules/security-foundation-security/securityhub.tf
@@ -1,0 +1,10 @@
+resource "aws_securityhub_organization_configuration" "sec_hub_org_config" {
+  auto_enable = true
+}
+
+resource "aws_securityhub_member" "members" {
+  for_each   = var.enable_member_account_invites ? var.security_hub_member_invite : {}
+  account_id = each.value.account_id
+  email      = each.value.email
+  depends_on = [aws_securityhub_organization_configuration.sec_hub_org_config]
+}

--- a/modules/security-foundation-security/variables.tf
+++ b/modules/security-foundation-security/variables.tf
@@ -14,3 +14,17 @@ variable "use_eks_runtime_monitoring" {
   type        = bool
   default     = true
 }
+
+variable "enable_member_account_invites" {
+  description = "Whether to enable inviting member accounts to Security Hub"
+  type        = bool
+  default     = true
+}
+
+variable "security_hub_member_invite" {
+  description = "Map of Security Hub member accounts to invite"
+  type = map(object({
+    account_id = string
+    email      = string
+  }))
+}

--- a/modules/securityhub-invite/.terraform.lock.hcl
+++ b/modules/securityhub-invite/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.0.0-beta3"
+  constraints = "6.0.0-beta3"
+  hashes = [
+    "h1:kMAaOX2uac8mLXzvfG1OODk0ue+sFsyFGFRyQVeaetU=",
+    "zh:2bc58cf176e0c365f5c7682430197a1c36b13b75f4ad6a4208efb6b654cd7164",
+    "zh:300222d1c5d51532f2dbf9ae1eb1ea10575cdd56f75c4c65ab8bceead4ee3669",
+    "zh:5799a243f98bdd20edf961ebcba05b65f12fe89014494fb4b75ac4e767972429",
+    "zh:596f99777bfc3971d0ff0329cba6797adc655149b45013ae9e32055f4d4ae9d8",
+    "zh:59c6bc732bd123c06c41b59e6a2b008692bf5984e6a13ec661c1de83ca02fe25",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9ba82f3280133a011987b014a58e9b1e13df61dc86c96ca4080562c2eef011e8",
+    "zh:a06e2029986a0f513c7fee2b52b04f3d758f705478ba40b353eae148fe02cafe",
+    "zh:a123235ce1f8a749968e5b14433311b3338f73f5244f36e1f2525265b5fe48f7",
+    "zh:b6ea3f8aa2389d4d9de86d4db43c2dbe0d269231727111d90730409b7252bb6e",
+    "zh:b921f0a15166e32beda68de3436da7dae81bedcb13c69517aef1624ea5f24d46",
+    "zh:d25cf251b15d98faf6d3d0dd1c9962be0893561a2d74f985e9a385b6806b593d",
+    "zh:d49aea36f0cfd5c40c8eae0beed38ef669e7d5e70236eaa7487c500916373053",
+    "zh:d9347b37fec437470ad5b77fe988ea678d4e8e91e4607c128460d915b7f529fd",
+    "zh:f81705821061f6acf4d145644ce603cf267936b9fe850380223ed3f31081e6d0",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.7.2"
+  constraints = "3.7.2"
+  hashes = [
+    "h1:KG4NuIBl1mRWU0KD/BGfCi1YN/j3F7H4YgeeM7iSdNs=",
+    "zh:14829603a32e4bc4d05062f059e545a91e27ff033756b48afbae6b3c835f508f",
+    "zh:1527fb07d9fea400d70e9e6eb4a2b918d5060d604749b6f1c361518e7da546dc",
+    "zh:1e86bcd7ebec85ba336b423ba1db046aeaa3c0e5f921039b3f1a6fc2f978feab",
+    "zh:24536dec8bde66753f4b4030b8f3ef43c196d69cccbea1c382d01b222478c7a3",
+    "zh:29f1786486759fad9b0ce4fdfbbfece9343ad47cd50119045075e05afe49d212",
+    "zh:4d701e978c2dd8604ba1ce962b047607701e65c078cb22e97171513e9e57491f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b8434212eef0f8c83f5a90c6d76feaf850f6502b61b53c329e85b3b281cba34",
+    "zh:ac8a23c212258b7976e1621275e3af7099e7e4a3d4478cf8d5d2a27f3bc3e967",
+    "zh:b516ca74431f3df4c6cf90ddcdb4042c626e026317a33c53f0b445a3d93b720d",
+    "zh:dc76e4326aec2490c1600d6871a95e78f9050f9ce427c71707ea412a2f2f1a62",
+    "zh:eac7b63e86c749c7d48f527671c7aee5b4e26c10be6ad7232d6860167f99dbb0",
+  ]
+}

--- a/modules/securityhub-invite/securityhub.tf
+++ b/modules/securityhub-invite/securityhub.tf
@@ -1,0 +1,13 @@
+resource "aws_securityhub_account" "invitee" {
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_securityhub_invite_accepter" "invitee" {
+  depends_on = [aws_securityhub_account.invitee]
+  master_id  = var.aws_securityhub_admin_account_id
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/modules/securityhub-invite/terraform.tf
+++ b/modules/securityhub-invite/terraform.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "6.0.0-beta3"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.7.2"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/securityhub-invite/variables.tf
+++ b/modules/securityhub-invite/variables.tf
@@ -1,0 +1,4 @@
+variable "aws_securityhub_admin_account_id" {
+  description = "Security Hub ID for the Security Hub admin account"
+  type        = string
+}

--- a/terraform.tf
+++ b/terraform.tf
@@ -42,3 +42,19 @@ provider "aws" {
   alias   = "security"
   profile = "security"
 }
+
+############################################################################
+# UnComment out this provider block if you are using a logging and product profile
+# and want to Enable invite acceptors for Security Hub
+############################################################################
+# provider "aws" {
+#   region  = "eu-west-1"
+#   alias   = "logging"
+#   profile = "logging"
+# }
+
+# provider "aws" {
+#   region  = "eu-west-1"
+#   alias   = "production"
+#   profile = "production"
+# }

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,4 +1,10 @@
-security_account_email = "user+security@email.com"
-logging_account_email = "user+logging@email.com"
-production_account_email = "user+production@email.com"
-security_account_id = "123456789012"
+management_account_email = "user@email.me"
+
+security_account_email   = "user+security@email.me"
+security_account_id      = "123456789"
+
+logging_account_email    = "user+logging@email.me"
+logging_account_id       = "123456789"
+
+production_account_email = "user+production@email.me"
+production_account_id    = "123456789"

--- a/variables.tf
+++ b/variables.tf
@@ -1,49 +1,7 @@
-variable "security_ou_name" {
-  description = "Name of the Security organizational unit"
+variable "management_account_email" {
+  description = "Email address for the management account"
   type        = string
-  default     = "Security"
-}
-
-
-variable "security_account_name" {
-  description = "Name of the security account"
-  type        = string
-  default     = "Security Account"
-}
-
-variable "security_account_email" {
-  description = "Email address for the security account"
-  type        = string
-}
-
-variable "logging_account_name" {
-  description = "Name of the logging account"
-  type        = string
-  default     = "Logging Account"
-
-}
-
-variable "logging_account_email" {
-  description = "Email address for the logging account"
-  type        = string
-}
-
-variable "production_account_name" {
-  description = "Name of the production account"
-  type        = string
-  default     = "Production Account"
-
-}
-
-variable "production_account_email" {
-  description = "Email address for the Production account"
-  type        = string
-}
-
-variable "product_ou_name" {
-  description = "Name of the product organizational unit"
-  type        = string
-  default     = "Product"
+  default     = "" # replace with actual management account email
 }
 
 variable "governed_regions" {
@@ -65,8 +23,88 @@ variable "validate_controls" {
   default     = false
 }
 
+# tflint-ignore: terraform_unused_declarations
+variable "enable_invite_acceptors" {
+  description = "Flag to enable invite acceptors for Security Hub"
+  type        = bool
+  default     = false
+}
+
+
+##################################################
+# Security Account Variables
+##################################################
+
+variable "security_ou_name" {
+  description = "Name of the Security organizational unit"
+  type        = string
+  default     = "Security"
+}
+
+
+variable "security_account_name" {
+  description = "Name of the security account"
+  type        = string
+  default     = "Security Account"
+}
+
+variable "security_account_email" {
+  description = "Email address for the security account"
+  type        = string
+}
+
 variable "security_account_id" {
   description = "AWS Account ID for the security account"
   type        = string
   default     = "" # replace with actual security account ID
+}
+
+##################################################
+# Logging Account Variables
+##################################################
+
+variable "logging_account_email" {
+  description = "Email address for the logging account"
+  type        = string
+}
+
+variable "logging_account_name" {
+  description = "Name of the logging account"
+  type        = string
+  default     = "Logging Account"
+}
+
+variable "logging_account_id" {
+  description = "AWS Account ID for the logging account"
+  type        = string
+  default     = "" # replace with actual logging account ID
+}
+
+##################################################
+# Production Account Variables
+##################################################
+
+
+variable "product_ou_name" {
+  description = "Name of the product organizational unit"
+  type        = string
+  default     = "Product"
+}
+
+variable "production_account_id" {
+  description = "AWS Account ID for the production account"
+  type        = string
+  default     = "" # replace with actual production account ID
+}
+
+variable "production_account_name" {
+  description = "Name of the production account"
+  type        = string
+  default     = "Production Account"
+
+}
+
+variable "production_account_email" {
+  description = "Email address for the Production account"
+  type        = string
 }


### PR DESCRIPTION
- adding securityhub initial settings in security-foundation-management to create securityhub and delegate admin
- adding securityhub in security-foundation-security to set up auto enrolling for all new accounts and invite new accounts
- adding optional code to invite accounts using a different method using the invitee resource in terraform